### PR TITLE
start ledger through the create endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from utils.db_config import get_db_connection, ledger
 from utils.docker_utils import build_docker_image, run_docker_container, stop_docker_container
 from utils.github_utils import recursive_repo_clone
 from utils.ledger_utils import calculate_new_balance, get_current_price, calculate_total_value
+from utils.ledger_manager import start_ledger
 from datetime import datetime
 import yfinance as yf
 
@@ -76,7 +77,10 @@ def create_ledger():
             conn.execute(stmt)
             conn.commit()
 
-        return jsonify({"info": f"Ledger '{name}' has been created."}), 201
+        # start ledger after creation
+        response, status_code = start_ledger(name)
+
+        return jsonify({"info": f"Ledger '{name}' has been created.", "start_status": response}), status_code
 
     except Exception as e:
         print(e)
@@ -201,34 +205,6 @@ def update_ledger():
     except Exception as e:
         print(e)
         return jsonify({"error": str(e)}), 500
-    
-
-@app.route("/start_ledger", methods=['POST'])
-def start_ledger():
-    """
-    This endpoint starts a ledger instance.
-    Expects: name of algorithm.
-    This function starts the task scheduling for the model using Huey.
-    """
-    name = request.args.get('name')
-
-    with get_db_connection() as conn:
-        stmt = select(
-            ledger.c.name,
-            ledger.c.update_time,
-            ledger.c.algo_link,
-            ledger.c.end_duration
-        ).where(ledger.c.name == name)
-        result = conn.execute(stmt).fetchone()
-    
-    if not result:
-        return {"Error": f"Ledger {name} does not exist."}, 404
-    
-    from utils.tasks import run_ledger_trade
-
-    run_ledger_trade(result.name, result.algo_link, result.update_time, result.end_duration)
-    
-    return {f"Ledger {name} will now start"}, 202
 
 
 if __name__ == "__main__":

--- a/utils/ledger_manager.py
+++ b/utils/ledger_manager.py
@@ -1,0 +1,30 @@
+from sqlalchemy import select
+from utils.db_config import get_db_connection, ledger
+from utils.tasks import run_ledger_trade
+
+def start_ledger(name):
+    """
+    Starts a ledger instance.
+
+    Args:
+        name (str): Name of the ledger to start.
+
+    Returns:
+        dict: A message indicating success or failure.
+        int: HTTP status code.
+    """
+    with get_db_connection() as conn:
+        stmt = select(
+            ledger.c.name,
+            ledger.c.update_time,
+            ledger.c.algo_link,
+            ledger.c.end_duration
+        ).where(ledger.c.name == name)
+        result = conn.execute(stmt).fetchone()
+
+    if not result:
+        return {"Error": f"Ledger {name} does not exist."}, 404
+
+    run_ledger_trade(result.name, result.algo_link, result.update_time, result.end_duration)
+
+    return {f"Ledger {name} will now start"}, 202


### PR DESCRIPTION
`start_ledger` is now automatically called when a ledger is created through the `create_ledger` endpoint. 

I decided to make `start_ledger` a helper function in the `utils` folder called `ledger_manager.py`. For the future, this module can be used for managing/orchestrating ledger-related tasks. 