### PR TITLE
Chore: Move docker client initialization into function

### DIFF
--- a/utils/docker_utils.py
+++ b/utils/docker_utils.py
@@ -1,10 +1,19 @@
 import docker
 import os
 
-client = docker.from_env()
+_docker_client = None
+
+
+def get_docker_client():
+    global _docker_client
+    if _docker_client is None:
+        _docker_client = docker.from_env()
+    return _docker_client
+
 
 def build_docker_image(name, dockerfile_path):
     try:
+        client = get_docker_client()
         image, logs = client.images.build(path=dockerfile_path, tag=name)
         return image
     except Exception as e:
@@ -13,6 +22,7 @@ def build_docker_image(name, dockerfile_path):
 
 def run_docker_container(image_name, command=None):
     try:
+        client = get_docker_client()
         container = client.containers.run(
             image_name,
             command=command
@@ -20,10 +30,11 @@ def run_docker_container(image_name, command=None):
         return container
     except Exception as e:
         raise RuntimeError(f"Error running Docker container: {e}")
-    
+
 
 def stop_docker_container(image_name):
     try:
+        client = get_docker_client()
         container = client.containers.get(image_name)
         container.stop()
     except docker.errors.NotFound:


### PR DESCRIPTION
- Ran into issues while mocking docker in my tests as it required me to run docker daemon which is not ideal
  - this is because pytest tries to connect to docker immediately before we get the chance to mock it 
- moving this initialization into a function fixes this as connection is only attempted when a function requests it, which occurs after test mocks are in place
- also lazy initialized client so that it's only created when needed and ensures we're not creating multiple connections