### PR TITLE
mock db connection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
 import pytest
-
 from tests.fixtures.fixture_artifact import sample_fixture
+from unittest.mock import patch, MagicMock
+
+@pytest.fixture
+def mock_db_connection():
+    with patch('utils.db_config.get_db_connection') as mock_get_db_connection:
+        mock_conn = MagicMock()
+        mock_get_db_connection.return_value.__enter__.return_value = mock_conn
+        yield mock_conn
+
 
 
 


### PR DESCRIPTION
This PR introduces a fixture to mock the database connection in our test suite, ensuring our unit tests run independently of a real database. The fixture is added to `conftest.py`, making it globally available for all tests.

How It Can Be Used
- Any test requiring a database connection can now include mock_db_connection as an argument.
- Prevents tests from relying on a real database, making them faster and more isolated.
- Can be reused across multiple test files without re-defining the mock.
