### PR TITLE
chore/ Unit tests for delete_ledger endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,9 +137,6 @@ def delete_ledger():
         stmt = select(ledger.c.name).where(ledger.c.name == name)
         result = conn.execute(stmt).fetchone()
 
-        # print(result)
-        # print(f"DELETE FROM {ORDERBOOKS_TABLE_NAME} WHERE name = '{name}';")
-
         if not result:
             return {
                 "Error": f"You are trying to delete a ledger called '{name}' that does not exist."

--- a/app.py
+++ b/app.py
@@ -127,13 +127,18 @@ def delete_ledger():
     """
     name = request.args.get("name")
 
+    if not name:
+        return {
+                "Error": f"You did not specify a ledger name. Usage: `/delete_ledger?name=insert_name`"
+            }, 400
+
     with get_db_connection() as conn:
         # check if the ledger exists in the database
         stmt = select(ledger.c.name).where(ledger.c.name == name)
         result = conn.execute(stmt).fetchone()
 
-        print(result)
-        print(f"DELETE FROM {ORDERBOOKS_TABLE_NAME} WHERE name = '{name}';")
+        # print(result)
+        # print(f"DELETE FROM {ORDERBOOKS_TABLE_NAME} WHERE name = '{name}';")
 
         if not result:
             return {

--- a/tests/test_functions/test_delete_ledger.py
+++ b/tests/test_functions/test_delete_ledger.py
@@ -1,0 +1,48 @@
+from flask import Flask, jsonify
+from unittest.mock import patch, MagicMock
+
+def test_delete_ledger_success(client, mock_db_connection):
+    """Test successful deletion"""
+    mock_select_result = MagicMock()
+    mock_select_result.fetchone.return_value = ("test_ledger",)
+    mock_db_connection.execute.return_value = mock_select_result
+
+    response = client.get("/delete_ledger?name=test_ledger")
+
+    # assertions
+    assert response.status_code == 200
+    assert response.json == {"Info": "Deleted ledger named 'test_ledger'"}
+
+    # verify that db functions were called
+    mock_db_connection.execute.assert_called()
+    mock_db_connection.commit.assert_called_once()  # ensure commit happened
+
+
+def test_delete_ledger_nonexistent(client, mock_db_connection):
+    """Test unsuccessful deletion in the case where the ledger dne"""
+    mock_select_result = MagicMock()
+    mock_select_result.fetchone.return_value = None  # select statement null
+    mock_db_connection.execute.return_value = mock_select_result
+
+    response = client.get("/delete_ledger?name=non_existent_ledger")
+
+    # assertions
+    assert response.status_code == 404
+    assert response.json == {
+        "Error": "You are trying to delete a ledger called 'non_existent_ledger' that does not exist."
+    }
+
+    # assert that conn.commit was NOT called
+    mock_db_connection.commit.assert_not_called()
+
+
+def test_delete_ledger_missing_param(client):
+    """Test unsuccessful deletion in the case the user does not provide a name param"""
+    response = client.get("/delete_ledger")
+
+    # assertions
+    assert response.status_code == 400
+    assert response.json == {
+        "Error": "You did not specify a ledger name. Usage: `/delete_ledger?name=insert_name`"
+    }
+


### PR DESCRIPTION
This PR is to test the `delete_ledger` endpoint.
- successful deletion
- unsuccessful deletion - nonexistent ledger
- unsuccessful deletion - missing 'name' parameter