### PR TITLE
Fix: Update ledger test failing due to private endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import patch, MagicMock, Mock
 from app import app
 
+
 @pytest.fixture
 def client():
     """Creating the test client"""
@@ -36,3 +37,10 @@ def mock_dependencies():
             'start_ledger': mock_start_ledger,
             'open': mock_open
         }
+
+
+@pytest.fixture(autouse=True)
+def mock_api_key_validation():
+    with patch('app.validate_api_key') as mock_validate:
+        mock_validate.return_value = True
+        yield mock_validate

--- a/tests/test_functions/test_update_ledger.py
+++ b/tests/test_functions/test_update_ledger.py
@@ -19,7 +19,8 @@ def test_update_ledger_nonexistent_ledger(client, mock_db_connection):
     response = client.patch(
         "/update_ledger",
         data=json.dumps(test_params),
-        content_type='application/json'
+        content_type='application/json',
+        headers={'X-API-Key': 'test-key'}
     )
 
     mock_db_connection.execute.assert_called()
@@ -37,7 +38,8 @@ def test_update_ledger_missing_fields(client, mock_db_connection):
     response = client.patch(
         "/update_ledger",
         data=json.dumps(test_params),
-        content_type='application/json'
+        content_type='application/json',
+        headers={'X-API-Key': 'test-key'}
     )
 
     mock_db_connection.execute.assert_not_called()


### PR DESCRIPTION
- Since we made our endpoints private, `update_ledger` test requires API key to be present
- This change adds a new fixture which mocks the API key validation